### PR TITLE
修复账号绑定相关的bug

### DIFF
--- a/src/components/Auth/login.vue
+++ b/src/components/Auth/login.vue
@@ -24,9 +24,6 @@
     </el-form>
     <div class="oauth-box">
       <h1 class="oauth-title">{{ $t('auth.otherAccount') }}</h1>
-      <p class="red" style="margin-bottom: 10px;">
-        {{ $t('auth.loginWarning') }}
-      </p>
       <div class="oauth">
         <div>
           <div class="oauth-bg bg-gray" @click="walletLogin('EOS')">

--- a/src/views/setting/account.vue
+++ b/src/views/setting/account.vue
@@ -28,6 +28,12 @@
           <span v-else>&nbsp;</span>
         </el-radio>
       </div>
+      <p class="list-p">
+        瞬Matataki支持绑定尚未注册的账号，账号解绑后可再次被绑定。
+      </p>
+      <p class="list-p">
+        已绑定的任意账号均可用于登录
+      </p>
     </div>
   </div>
 </template>
@@ -402,7 +408,7 @@ export default {
     },
     accountChangeFunc(label, idx) {
       if (!this.isLogined) return this.$store.commit('setLoginModal', true)
-      if (!this.accountList[idx].status) return this.$message.warning('请先绑定账号')
+      if (!this.accountList[idx].status) return this.$message.warning('绑定后才可设置为主账号')
       if (label === 'email') {
         this.$prompt('请输入邮箱密码', '提示', {
           confirmButtonText: '确定',
@@ -618,5 +624,9 @@ export default {
       }
     }
   }
+}
+.list-p{
+  font-size: 12px;
+  color: #555555;
 }
 </style>


### PR DESCRIPTION
去掉在登录面板上的文字 “不同账号之间内容不互通”
在账号管理页面中增加固定文字显示
设置主账号失败的提示文字为：“绑定后才可设置为主账号”