### PR TITLE
注销账号以及文章发布页有关的两项更新

### DIFF
--- a/src/components/comment/article_card.vue
+++ b/src/components/comment/article_card.vue
@@ -8,8 +8,8 @@
         <avatar :src="avatar" size="30px" ></avatar>
       </router-link>
       <div>
-        <router-link class="comment-author" :to="`/user/${comment.uid}`">
-          {{ comment.nickname || comment.username }}
+        <router-link class="comment-author" :class="!comment.username && 'logout'" :to="`/user/${comment.uid}`">
+          {{ nickname }}
           <span>
             {{ friendlyDate }}
           </span>
@@ -49,6 +49,9 @@ export default {
     avatar() {
       if (this.comment.avatar) return this.$ossProcess(this.comment.avatar, {h: 60})
       return ''
+    },
+    nickname() {
+      return this.comment.nickname || this.comment.username || '此账号已注销'
     }
   }
 }
@@ -74,6 +77,9 @@ export default {
   padding: 0;
   margin: 4px 0;
   display: inline-block;
+  &.logout {
+    color: #b2b2b2;
+  }
   span {
     color: #9c9c9c;
     margin-left: 10px;

--- a/src/views/publish/index.less
+++ b/src/views/publish/index.less
@@ -311,3 +311,33 @@
     margin: 4px 0;
   }
 }
+
+.related-add {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: 6px 0 0;
+
+  span {
+    font-size: 14px;
+    color: #949494;
+    margin-left: 6px;
+  }
+}
+
+.add-icon {
+  width: 24px;
+  height: 24px;
+  background-color: @purpleDark;
+  color: #fff;
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &.disable {
+    background-color: #DBDBDB;
+    cursor: no-drop;
+  }
+}

--- a/src/views/publish/index.vue
+++ b/src/views/publish/index.vue
@@ -104,6 +104,14 @@
             </div>
           </div>
         </transition>
+        <div v-show="readauThority" class="related-add">
+          <el-tooltip effect="dark" content="多Fan票解锁正在开发中" placement="top">
+            <div class="add-icon disable">
+              <i class="el-icon-plus" />
+            </div>
+          </el-tooltip>
+          <span>添加更多</span>
+        </div>
         <el-checkbox v-model="paymentTokenVisible" size="small" style="margin-top: 10px;">
           设置支付
         </el-checkbox>
@@ -153,6 +161,27 @@
             />
           </div>
         </transition>
+      </div>
+      
+      <!-- 编辑权限 （功能开发中） -->
+      <div class="post-content">
+        <div>
+          <h3>
+            编辑权限 （功能开发中）
+            <el-tooltip class="item" effect="dark" placement="top-start">
+              <div slot="content">
+                添加编辑权限后，<br />读者在持有特定数量的Fan票或支付特定费用后可编辑文章。
+              </div>
+              <svg-icon class="help-icon" icon-class="help" />
+            </el-tooltip>
+          </h3>
+          <el-checkbox size="small" disabled>
+            设置持Fan票
+          </el-checkbox>
+        </div>
+        <el-checkbox size="small" style="margin-top: 10px;" disabled>
+          设置支付
+        </el-checkbox>
       </div>
 
       <div v-if="$route.params.type !== 'edit'" class="fission">


### PR DESCRIPTION
1. 注销账号后在评论区显示“此账号已注销”
2. 文章发布中添加 “编辑权限” 和 “添加更多Fan票” 的 UI 并且标注为开发中
   - https://github.com/Matataki-io/Matataki-FE/issues/197